### PR TITLE
TIMBA_DATA_DIR defines a path to the data. See issue TI-Forest-Sector…

### DIFF
--- a/TiMBA/__init__.py
+++ b/TiMBA/__init__.py
@@ -1,0 +1,16 @@
+"""
+This is where the main page of the auto generated documentation website can be.
+
+`TIMBA_DATA_DIR` can be either pre-defined and hard coded in the default case,
+or it can be defined through an environmental variable.
+
+"""
+
+from pathlib import Path
+
+# Path do the data, default case
+TIMBA_DATA_DIR = Path.home() / "timba_data"
+# Or defined through an environmental
+if os.environ.get("TIMBA_DATA_DIR"):
+    TIMBA_DATA_DIR = Path(os.environ["TIMBA_DATA_DIR"])
+


### PR DESCRIPTION

Creating a TIMBA_DATA_DIR variable that can be eigher hard coded inside TiMBA or defined through an enviromental variable. This helps define the path to the data on clusters or CI, or machines where you don't necessarily want the data to be inside the package repository itself. This also helps other packages such as TiMBA Charts know where the data is located. More details in : 

https://github.com/TI-Forest-Sector-Modelling/TiMBA/issues/72